### PR TITLE
fix for Gnome 3.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Display Profile Manager
 Create and manage display profiles and access them easy in the GNOME Shell. A profile consists of one or multiple monitors with its configuration (e.g.: resolution, rotation, refresh rate...).  
 This extension uses GNOME libraries for detecting and setting the screen configuration. Therefore GNOME will remember the last active profile also after reboot. The behaviour on monitor changes (attaching or removing) is still handled by GNOME, but the extension keeps track of it and offers only available profiles.
 
-**Supported GNOME Shell versions:** 3.4, 3.6, 3.8  
+**Supported GNOME Shell versions:** 3.4-3.16 
 **Installation:** Official [GNOME Shell Extensions](https://extensions.gnome.org/extension/688/display-profile-manager) Site
 
 ![Screenshot](https://raw.github.com/bodedejavu/gnome-shell-extensions/master/screenshot1.png)

--- a/display-profile-manager@bodedejavu.github.com/metadata.json
+++ b/display-profile-manager@bodedejavu.github.com/metadata.json
@@ -3,6 +3,6 @@
     "name": "Display Profile Manager",
     "description": "Create and manage display profiles and access them easy in the GNOME Shell. A profile consists of one or multiple monitors with its configuration (e.g.: resolution, rotation, refresh rate...).\nThis extension uses GNOME libraries for detecting and setting the screen configuration. Therefore GNOME will remember the last active profile also after reboot. The behaviour on monitor changes (attaching or removing) is still handled by GNOME, but the extension keeps track of it and offers only available profiles.",
     "url": "https://github.com/bodedejavu/gnome-shell-extensions",
-    "shell-version": ["3.4", "3.6", "3.8", "3.10", "3.12"],
+    "shell-version": ["3.4", "3.6", "3.8", "3.10", "3.12", "3.14", "3.16"],
     "settings-schema": "org.gnome.shell.extensions.display-profile-manager"
 }

--- a/display-profile-manager@bodedejavu.github.com/newer.js
+++ b/display-profile-manager@bodedejavu.github.com/newer.js
@@ -212,7 +212,14 @@ const DisplayProfileManager = new Lang.Class({
                 keybinding_name = Common.SETTINGS_KEY_KEYBINDING_PROFILE + (profileIndex+1).toString();
                 keybinding_handler = Lang.bind(this, this._setProfileFromKeybinding, this._profiles[profileIndex]);
                 if (Main.wm.addKeybinding) {
-                    keybinding = Main.wm.addKeybinding(keybinding_name, this._settings, Meta.KeyBindingFlags.NONE, Shell.KeyBindingMode.NORMAL | Shell.KeyBindingMode.MESSAGE_TRAY, keybinding_handler);
+                    let bindingMode;
+                    if (Shell.ActionMode) {
+                        bindingMode = Shell.ActionMode.NORMAL | Shell.ActionMode.MESSAGE_TRAY; 
+                        }
+                    else {
+                        bindingMode = Shell.KeyBindingMode.NORMAL | Shell.KeyBindingMode.MESSAGE_TRAY;
+                        }
+                    keybinding = Main.wm.addKeybinding(keybinding_name, this._settings, Meta.KeyBindingFlags.NONE, bindingMode, keybinding_handler);
                     }
                 else {
                     keybinding = global.display.add_keybinding(keybinding_name, this._settings, Meta.KeyBindingFlags.NONE, keybinding_handler);

--- a/display-profile-manager@bodedejavu.github.com/older.js
+++ b/display-profile-manager@bodedejavu.github.com/older.js
@@ -170,8 +170,16 @@ const DisplayProfileManager = new Lang.Class({
                 
                 keybinding_name = Common.SETTINGS_KEY_KEYBINDING_PROFILE + (profileNumber+1).toString();
                 keybinding_handler = Lang.bind(this, this._setProfileFromKeybinding, config, outputs, profile);
+                
                 if (Main.wm.addKeybinding) {
-                    keybinding = Main.wm.addKeybinding(keybinding_name, this._settings, Meta.KeyBindingFlags.NONE, Shell.KeyBindingMode.NORMAL | Shell.KeyBindingMode.MESSAGE_TRAY, keybinding_handler);
+                    let bindingMode;
+                    if (Shell.ActionMode) {
+                        bindingMode = Shell.ActionMode.NORMAL | Shell.ActionMode.MESSAGE_TRAY;
+                        }
+                    else {
+                        bindingMode = Shell.KeyBindingMode.NORMAL | Shell.KeyBindingMode.MESSAGE_TRAY;
+                        }
+                    keybinding = Main.wm.addKeybinding(keybinding_name, this._settings, Meta.KeyBindingFlags.NONE, bindingMode, keybinding_handler);
                     }
                 else {
                     keybinding = global.display.add_keybinding(keybinding_name, this._settings, Meta.KeyBindingFlags.NONE, keybinding_handler);


### PR DESCRIPTION
Shell.KeybindingMode was renamed Shell.ActionMode in gnome-shell 3.16

This change verifies that Shell.ActionMode exists. If so, it uses the new name. Otherwise it uses the old name.

I cannot test on gnome-shell 3.14, however.
